### PR TITLE
Resolve conflicting licences in LICENSE file and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)"
   ],
   "keywords": [],
-  "license": "MIT",
+  "license": "MITNFA",
   "dependencies": {
     "after": "~0.8.1",
     "brucedown": "~1.1.1"


### PR DESCRIPTION
This PR updates the package.json to accurately reflect the license wishes of the author when using tools that aggregate licence disclosures for distribution.

[SPDX now lists MITNFA](https://spdx.org/licenses/MITNFA.html) as a license and thus is recognized by npm instead of the currently multi-licensed state of this package.